### PR TITLE
Select archspecific varian of libunwind, if available

### DIFF
--- a/src/deps/libbacktrace/cmake/FindUnwind.cmake
+++ b/src/deps/libbacktrace/cmake/FindUnwind.cmake
@@ -1,9 +1,18 @@
 
+
+set(UNWINDARCH unwind-${CMAKE_SYSTEM_PROCESSOR})
+
 find_path(LIBUNWIND_INCLUDE_DIR unwind.h)
 find_library(LIBUNWIND_LIBRARY NAMES unwind)
+find_library(LIBUNWIND_LIBRARY_ARCH NAMES ${UNWINDARCH})
 find_library(LIBUNWIND_PTRACE_LIBRARY NAMES unwind-ptrace)
 
-if(LIBUNWIND_INCLUDE_DIR AND LIBUNWIND_LIBRARY AND LIBUNWIND_PTRACE_LIBRARY)
+if(LIBUNWIND_INCLUDE_DIR AND LIBUNWIND_PTRACE_LIBRARY AND (LIBUNWIND_LIBRARY OR LIBUNWIND_LIBRARY_ARCH))
+   # assuming we're not cross-compiling, arch-specific lib is better
+   # hence overwrited the library name
+   if (LIBUNWIND_LIBRARY_ARCH)
+      set(LIBUNWIND_LIBRARY ${LIBUNWIND_LIBRARY_ARCH})
+   endif()
    set(UNWIND_FOUND TRUE)
 endif()
 


### PR DESCRIPTION
Should not break anything, but fixes issue with ubuntu 14.04